### PR TITLE
Add multiple case condition example to switch statement

### DIFF
--- a/GO-Project/basics/switch.go
+++ b/GO-Project/basics/switch.go
@@ -14,4 +14,12 @@ func main() {
 	default:
 		f.Println("A is not 10 or 20")
 	}
+
+
+	switch a{
+	case 10,20://Multiple case condition
+		f.Println("A is 10 or 20")
+	default:
+		f.Println("A is not 10 or 20")
+	}
 }


### PR DESCRIPTION
Demonstrate how to use comma-separated values in a single case clause for handling multiple conditions in Go switch statements.