### PR TITLE
docs: add comments explaining allowed map key types in Go

### DIFF
--- a/GO-Project/basics/map.go
+++ b/GO-Project/basics/map.go
@@ -40,4 +40,25 @@ func main() {
 	b["key"] = 10
 	b["value"] = 20
 	f.Println(b, r.TypeOf(b))
+
+
+	// Allowed Key Types
+
+// 	The map key can be of any data type for which the equality operator (==) is defined. These include:
+
+// Booleans
+// Numbers
+// Strings
+// Arrays
+// Pointers
+// Structs
+// Interfaces (as long as the dynamic type supports equality)
+// Invalid key types are:
+
+// Slices
+// Maps
+// Functions
+//These types are invalid because the equality operator (==) is not defined for them.
+
+
 }


### PR DESCRIPTION
Added comprehensive documentation about valid and invalid key types for Go maps, including examples of types where equality operator is defined (booleans, numbers, strings, arrays, pointers, structs, interfaces) and types that cannot be used as keys (slices, maps, functions).