### PR TITLE
feat: add map initialization and value access example in map.go

### DIFF
--- a/GO-Project/basics/map.go
+++ b/GO-Project/basics/map.go
@@ -60,5 +60,13 @@ func main() {
 // Functions
 //These types are invalid because the equality operator (==) is not defined for them.
 
+ var p = make(map[string]string)
+  p["brand"] = "Ford"
+  p["brand"] = "Ford"
+  p["model"] = "Mustang"
+  p["year"] = "1964"
+
+  f.Printf(p["brand"])
+
 
 }


### PR DESCRIPTION
Add example demonstrating map creation with make(), key-value assignment, and value retrieval using Printf to illustrate basic map operations in Go.