### PR TITLE
feat(basics): add map key existence check example

### DIFF
--- a/GO-Project/basics/map.go
+++ b/GO-Project/basics/map.go
@@ -86,5 +86,13 @@ delete(p, "model")
 f.Println(p)
 
 
+// Check For Specific Elements in a Map
+// Syntax
+// val, ok :=map_name[key]
+
+val, ok := p["VBN"]
+f.Println(val, ok)//val actaull value of year if the key is there and ok will be true else it will be false
+
+
 
 }


### PR DESCRIPTION
Add example demonstrating Go's comma ok idiom for checking if a key exists in a map, including syntax documentation and practical usage with the existing map variable.