### PR TITLE
feat(basics): add map creation example using make()

### DIFF
--- a/GO-Project/basics/map.go
+++ b/GO-Project/basics/map.go
@@ -93,6 +93,7 @@ f.Println(p)
 val, ok := p["VBN"]
 f.Println(val, ok)//val actaull value of year if the key is there and ok will be true else it will be false
 
-
+var l =make(map[string]int)
+f.Println(l, r.TypeOf(l))
 
 }


### PR DESCRIPTION
Add example demonstrating map initialization using make() function with type inspection. Shows how to create an empty map[string]int and print its type using reflection.