### PR TITLE
docs(go-basics): demonstrate map reference behavior

### DIFF
--- a/GO-Project/basics/map.go
+++ b/GO-Project/basics/map.go
@@ -96,4 +96,16 @@ f.Println(val, ok)//val actaull value of year if the key is there and ok will be
 var l =make(map[string]int)
 f.Println(l, r.TypeOf(l))
 
+f.Println(l["key"])
+
+
+// Maps are references to hash tables.
+
+// If two map variables refer to the same hash table, changing the content of one variable affect the content of the other.
+
+var k=p
+k["year"] = "1190"
+f.Println(k, r.TypeOf(k))
+f.Println(p, r.TypeOf(p))
+
 }


### PR DESCRIPTION
Add example code and comments showing that Go maps are references to hash tables. When two map variables refer to the same underlying hash table, modifications through one variable affect the other. This demonstrates the reference semantics of maps in Go by assigning one map to another and showing how changes to one are reflected in both.