### PR TITLE
feat(basics): add map iteration example using range

### DIFF
--- a/GO-Project/basics/map.go
+++ b/GO-Project/basics/map.go
@@ -108,4 +108,11 @@ k["year"] = "1190"
 f.Println(k, r.TypeOf(k))
 f.Println(p, r.TypeOf(p))
 
+// Iterate Over Maps
+// You can use range to iterate over maps.
+
+for key,value := range p{
+	f.Println(key, value)
+}
+
 }


### PR DESCRIPTION
Add example demonstrating how to iterate over maps in Go using the range keyword. The new code shows proper syntax for accessing both keys and values while looping through a map, complementing the existing map operations examples.