### PR TITLE
feat(basics): add closure example demonstrating anonymous functions

### DIFF
--- a/GO-Project/basics/closure.go
+++ b/GO-Project/basics/closure.go
@@ -1,0 +1,34 @@
+package main
+
+
+import "fmt"
+
+func intSeq() func() int {
+    i := 0
+    return func() int {
+        i++
+        return i
+    }
+}
+
+func main() {
+
+    nextInt := intSeq()
+
+    fmt.Println(nextInt())
+    fmt.Println(nextInt())
+    fmt.Println(nextInt())
+
+    newInts := intSeq()
+    fmt.Println(newInts())
+}
+
+
+
+// Go supports anonymous functions, which can form closures. Anonymous functions are useful when you want to define a function inline without having to name it.
+
+// This function intSeq returns another function, which we define anonymously in the body of intSeq. The returned function closes over the variable i to form a closure.
+
+// We call intSeq, assigning the result (a function) to nextInt. This function value captures its own i value, which will be updated each time we call nextInt.
+
+// See the effect of the closure by calling nextInt a few times.


### PR DESCRIPTION
Add a new Go example file that demonstrates closures and anonymous functions. The example includes an `intSeq()` function that returns a closure which captures and increments a counter variable. This illustrates how Go functions can maintain state through closure variables and how each closure instance maintains its own separate state. Includes detailed comments explaining closure behavior and practical usage examples.