### PR TITLE
feat(basics): add variadic functions example in Go

### DIFF
--- a/GO-Project/basics/variadic_functions.go
+++ b/GO-Project/basics/variadic_functions.go
@@ -1,0 +1,26 @@
+package main
+
+import "fmt"
+
+func sum(nums ...int) {
+    fmt.Print(nums, " ")
+    total := 0
+
+    for _, num := range nums {
+        total += num
+    }
+    fmt.Println(total)
+}
+
+func main() {
+
+    sum(1, 2)
+    sum(1, 2, 3)
+
+    nums := []int{1, 2, 3, 4}
+    sum(nums...)
+}
+
+
+// Variadic functions can be called with any number of trailing arguments. 
+// For example, fmt.Println is a common variadic function.


### PR DESCRIPTION
Add a new example demonstrating variadic functions in Go, including:
- Implementation of a sum function that accepts variable number of arguments
- Examples of calling variadic functions with direct arguments
- Demonstration of slice expansion syntax (nums...) for passing slices
- Explanatory comments about variadic function usage

This example helps illustrate how to work with functions that can accept any number of trailing arguments, a common pattern in Go (e.g., fmt.Println).