### PR TITLE
feat(basics): add range iteration examples for Go built-in types

### DIFF
--- a/GO-Project/basics/range_over_built_in_types.go
+++ b/GO-Project/basics/range_over_built_in_types.go
@@ -1,0 +1,32 @@
+package main
+
+import "fmt"
+
+func main() {
+
+    nums := []int{2, 3, 4}
+    sum := 0
+    for _, num := range nums {
+        sum += num
+    }
+    fmt.Println("sum:", sum)
+
+    for i, num := range nums {
+        if num == 3 {
+            fmt.Println("index:", i)
+        }
+    }
+
+    kvs := map[string]string{"a": "apple", "b": "banana"}
+    for k, v := range kvs {
+        fmt.Printf("%s -> %s\n", k, v)
+    }
+
+    for k := range kvs {
+        fmt.Println("key:", k)
+    }
+
+    for i, c := range "go" {
+        fmt.Println(i, c)
+    }
+}


### PR DESCRIPTION
Add comprehensive examples demonstrating range usage in Go:
- Iterate over slices with sum calculation and index lookup
- Iterate over maps for both key-value pairs and keys only
- Iterate over strings to access characters and indices

This educational example showcases different patterns for using the range keyword with various built-in data types in Go.