### PR TITLE
feat(basics): add pointers example demonstrating value vs reference

### DIFF
--- a/GO-Project/basics/pointers.go
+++ b/GO-Project/basics/pointers.go
@@ -1,0 +1,30 @@
+package main
+
+import "fmt"
+
+func zeroval(ival int) {
+    ival = 0
+}
+
+func zeroptr(iptr *int) {
+    *iptr = 0
+}
+
+func main() {
+    i := 1
+    fmt.Println("initial:", i)
+
+    zeroval(i)
+    fmt.Println("zeroval:", i)
+
+    zeroptr(&i)
+    fmt.Println("zeroptr:", i)
+
+    fmt.Println("pointer:", &i)
+// }
+// We’ll show how pointers work in contrast to values with 2 functions: zeroval and zeroptr. zeroval has an int parameter, so arguments will be passed to it by value. 
+// zeroval will get a copy of ival distinct from the one in the calling function.
+
+// zeroptr in contrast has an *int parameter, meaning that it takes an int pointer. 
+// The *iptr code in the function body then dereferences the pointer from its memory address to the current value at that address. 
+// Assigning a value to a dereferenced pointer changes the value at the referenced address.


### PR DESCRIPTION
Add new pointers.go file that illustrates the difference between pass-by-value and pass-by-reference in Go:
- Implement zeroval() function showing pass-by-value behavior
- Implement zeroptr() function demonstrating pointer dereferencing
- Include main() with practical examples of both approaches
- Add explanatory comments about pointer mechanics and memory addressing

This example helps understand how Go handles values and pointers differently, particularly useful for learning when modifications need to persist beyond function scope.