### PR TITLE
feat(basics): add strings and runes example in Go

### DIFF
--- a/GO-Project/basics/strings_and_runes.go
+++ b/GO-Project/basics/strings_and_runes.go
@@ -1,0 +1,48 @@
+
+// A Go string is a read-only slice of bytes. 
+// The language and the standard library treat strings specially - as containers of text encoded in UTF-8. In other languages, strings are made of “characters”. 
+// In Go, the concept of a character is called a rune - it’s an integer that represents a Unicode code point. 
+// This Go blog post is a good introduction to the topic.
+
+package main
+
+import (
+    "fmt"
+    "unicode/utf8"
+)
+
+func main() {
+
+    const s = "สวัสดี"
+
+    fmt.Println("Len:", len(s))
+
+    for i := 0; i < len(s); i++ {
+        fmt.Printf("%x ", s[i])
+    }
+    fmt.Println()
+
+    fmt.Println("Rune count:", utf8.RuneCountInString(s))
+
+    for idx, runeValue := range s {
+        fmt.Printf("%#U starts at %d\n", runeValue, idx)
+    }
+
+    fmt.Println("\nUsing DecodeRuneInString")
+    for i, w := 0, 0; i < len(s); i += w {
+        runeValue, width := utf8.DecodeRuneInString(s[i:])
+        fmt.Printf("%#U starts at %d\n", runeValue, i)
+        w = width
+
+        examineRune(runeValue)
+    }
+}
+
+func examineRune(r rune) {
+
+    if r == 't' {
+        fmt.Println("found tee")
+    } else if r == 'ส' {
+        fmt.Println("found so sua")
+    }
+}


### PR DESCRIPTION
Add comprehensive example demonstrating Go string and rune handling, including:
- UTF-8 byte representation of strings
- Rune counting and iteration methods
- Manual rune decoding with utf8.DecodeRuneInString
- Character examination function

This example uses Thai text (สวัสดี) to illustrate the difference between byte length and rune count in UTF-8 encoded strings, providing a practical reference for Unicode handling in Go.